### PR TITLE
Relocate info popover to navbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { Nav } from '@/components/nav'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: '학교 정보',
+  // title: '학교 정보',
   description: '학교 정보를 확인하세요',
   generator: 'Next.js',
   openGraph: {


### PR DESCRIPTION
Info popover was relocated to navigation bar

<img width="889" alt="image" src="https://github.com/user-attachments/assets/f9e676eb-8b4a-499b-8fdc-4ea643464953" />


I believe this better fits the design language. It's totally optional to accept it though. 
Mobile environment has been tested. 